### PR TITLE
feat: Create ChatGPT-style chat app with Svelte and Tailwind CSS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -195,3 +195,17 @@ uv.lock
 
 # Environment variables
 .env
+
+# Node.js / npm
+node_modules/
+npm-debug.log
+yarn.lock
+package-lock.json
+
+# Vite
+dist/
+.vite/
+
+# IDE
+.idea/
+.vscode/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,136 @@
 # Claude AGI
+
+## ChatGPT風チャットアプリ
+
+SvelteとTailwind CSSで作成されたシンプルなチャットアプリです。
+
+### 機能
+
+- **リアルタイムチャット**: メッセージの送受信
+- **レスポンシブデザイン**: モバイル対応
+- **ローカルストレージ**: チャット履歴の自動保存
+- **ダークテーマ**: ChatGPT風のUI
+
+### セットアップ手順
+
+#### 1. 必要な環境
+
+- Node.js 18.0以上
+- npm または yarn
+
+#### 2. 依存関係のインストール
+
+```bash
+npm install
+```
+
+#### 3. 開発サーバーの起動
+
+```bash
+npm run dev
+```
+
+ブラウザで `http://localhost:5173` を開くと、アプリが表示されます。
+
+#### 4. 本番環境用のビルド
+
+```bash
+npm run build
+```
+
+このコマンドは `dist` ディレクトリに最適化されたファイルを生成します。
+
+### GitHub Pages への デプロイ
+
+このアプリをGitHub Pagesで公開するには、以下の手順に従ってください。
+
+#### 1. リポジトリ設定
+
+`vite.config.js` の `base` を設定します（既に設定済み）：
+
+```javascript
+export default defineConfig({
+  plugins: [svelte()],
+  base: '/claude-agi/',  // リポジトリ名に置き換え
+})
+```
+
+#### 2. GitHub Actions設定
+
+`.github/workflows/deploy.yml` を作成してCI/CDパイプラインを設定できます。
+
+または、手動でビルドしてデプロイできます：
+
+```bash
+# ビルド
+npm run build
+
+# dist ディレクトリを gh-pages ブランチにデプロイ
+# gh CLI を使用する場合：
+npx gh-pages -d dist
+```
+
+#### 3. リポジトリ設定
+
+- GitHub の **Settings** → **Pages** に移動
+- **Source** を `gh-pages` ブランチに設定
+- 保存すると、`https://username.github.io/claude-agi/` でアクセス可能になります
+
+### プロジェクト構成
+
+```
+.
+├── src/
+│   ├── App.svelte              # メインアプリケーション
+│   ├── app.css                 # グローバルスタイル
+│   ├── main.js                 # エントリーポイント
+│   └── components/
+│       ├── ChatContainer.svelte # チャット全体
+│       ├── MessageList.svelte   # メッセージ表示
+│       ├── Message.svelte       # 単一メッセージ
+│       └── ChatInput.svelte     # 入力フォーム
+├── index.html                  # HTMLテンプレート
+├── vite.config.js              # Viteの設定
+├── tailwind.config.js          # Tailwindの設定
+├── postcss.config.js           # PostCSSの設定
+├── svelte.config.js            # Svelteの設定
+└── package.json                # 依存関係定義
+```
+
+### 主な技術スタック
+
+- **Svelte 4**: UIフレームワーク
+- **Vite**: 高速なビルドツール
+- **Tailwind CSS 3**: ユーティリティファーストCSSフレームワーク
+- **JavaScript**: 言語
+
+### 使用方法
+
+1. テキストボックスにメッセージを入力
+2. 「送信」ボタンをクリックまたはEnterキーで送信
+3. アシスタントがランダムな応答を返す
+4. チャット履歴はローカルストレージに自動保存される
+
+### カスタマイズ
+
+#### レスポンスの変更
+
+`src/components/ChatContainer.svelte` の `responses` 配列を編集して、アシスタントの応答メッセージをカスタマイズできます。
+
+#### スタイルの変更
+
+Tailwind CSSのクラスを編集してデザインをカスタマイズできます。また、`tailwind.config.js` でテーマを設定できます。
+
+### トラブルシューティング
+
+**ビルドエラー**: 依存関係を再インストールしてください
+```bash
+rm -rf node_modules package-lock.json
+npm install
+```
+
+**ローカルストレージがクリアされた**: ブラウザの開発者ツール → Application → Local Storage → サイトを選択して確認できます。
+
+### ライセンス
+
+MIT License

--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Chat Assistant</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.js"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "svelte-chat-app",
+  "private": true,
+  "version": "0.0.1",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "lint": "eslint . --ext .js,.svelte"
+  },
+  "devDependencies": {
+    "@sveltejs/vite-plugin-svelte": "^3.0.0",
+    "vite": "^5.0.0",
+    "svelte": "^4.0.0",
+    "tailwindcss": "^3.3.0",
+    "postcss": "^8.4.31",
+    "autoprefixer": "^10.4.16"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,0 +1,17 @@
+<script>
+  import ChatContainer from './components/ChatContainer.svelte'
+</script>
+
+<div class="h-screen bg-gray-900">
+  <ChatContainer />
+</div>
+
+<style global>
+  :global(body) {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
+      'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
+      sans-serif;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
+</style>

--- a/src/app.css
+++ b/src/app.css
@@ -1,0 +1,9 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}

--- a/src/components/ChatContainer.svelte
+++ b/src/components/ChatContainer.svelte
@@ -1,0 +1,75 @@
+<script>
+  import MessageList from './MessageList.svelte'
+  import ChatInput from './ChatInput.svelte'
+  import { onMount } from 'svelte'
+
+  let messages = []
+
+  onMount(() => {
+    // Load messages from localStorage
+    const saved = localStorage.getItem('chat_messages')
+    if (saved) {
+      messages = JSON.parse(saved)
+    } else {
+      // Initial greeting message
+      messages = [
+        {
+          id: 1,
+          text: 'こんにちは！何かお手伝いできることはありますか？',
+          sender: 'assistant',
+          timestamp: new Date()
+        }
+      ]
+    }
+  })
+
+  function handleSendMessage(event) {
+    const userMessage = {
+      id: Date.now(),
+      text: event.detail,
+      sender: 'user',
+      timestamp: new Date()
+    }
+
+    messages = [...messages, userMessage]
+
+    // Simulate assistant response
+    setTimeout(() => {
+      const responses = [
+        'それはいいアイデアですね！',
+        'なるほど、理解しました。',
+        'もっと詳しく教えていただけますか？',
+        'そうですね、確認させてください。',
+        '他にご質問があればお聞きします。'
+      ]
+
+      const randomResponse = responses[Math.floor(Math.random() * responses.length)]
+
+      const assistantMessage = {
+        id: Date.now() + 1,
+        text: randomResponse,
+        sender: 'assistant',
+        timestamp: new Date()
+      }
+
+      messages = [...messages, assistantMessage]
+      saveMessages()
+    }, 500)
+
+    saveMessages()
+  }
+
+  function saveMessages() {
+    localStorage.setItem('chat_messages', JSON.stringify(messages))
+  }
+</script>
+
+<div class="flex flex-col h-full">
+  <div class="bg-gray-800 border-b border-gray-700 px-4 py-3">
+    <h1 class="text-white text-lg font-semibold">Chat Assistant</h1>
+  </div>
+
+  <MessageList {messages} />
+
+  <ChatInput on:sendMessage={handleSendMessage} />
+</div>

--- a/src/components/ChatInput.svelte
+++ b/src/components/ChatInput.svelte
@@ -1,0 +1,66 @@
+<script>
+  import { createEventDispatcher } from 'svelte'
+
+  const dispatch = createEventDispatcher()
+
+  let input = ''
+  let isLoading = false
+
+  function handleSend() {
+    if (input.trim()) {
+      dispatch('sendMessage', input)
+      input = ''
+    }
+  }
+
+  function handleKeydown(e) {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault()
+      handleSend()
+    }
+  }
+</script>
+
+<div class="border-t border-gray-700 bg-gray-800 px-4 py-4">
+  <div class="max-w-4xl mx-auto flex gap-3">
+    <textarea
+      bind:value={input}
+      on:keydown={handleKeydown}
+      placeholder="メッセージを入力..."
+      class="flex-1 bg-gray-700 text-white rounded-lg px-4 py-3 resize-none focus:outline-none focus:ring-2 focus:ring-blue-500 placeholder-gray-500"
+      rows="1"
+    />
+    <button
+      on:click={handleSend}
+      disabled={!input.trim() || isLoading}
+      class="bg-blue-600 hover:bg-blue-700 disabled:bg-gray-600 disabled:cursor-not-allowed text-white rounded-lg px-6 py-3 font-medium transition-colors flex items-center gap-2"
+    >
+      <span>送信</span>
+      {#if isLoading}
+        <svg class="animate-spin h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+          <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+          <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+        </svg>
+      {/if}
+    </button>
+  </div>
+</div>
+
+<style>
+  textarea {
+    max-height: 200px;
+  }
+
+  textarea::-webkit-scrollbar {
+    width: 4px;
+  }
+
+  textarea::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  textarea::-webkit-scrollbar-thumb {
+    background-color: rgb(75, 85, 99);
+    border-radius: 2px;
+  }
+</style>

--- a/src/components/Message.svelte
+++ b/src/components/Message.svelte
@@ -1,0 +1,30 @@
+<script>
+  export let message
+
+  $: isUser = message.sender === 'user'
+  $: bgClass = isUser ? 'bg-blue-600' : 'bg-gray-700'
+  $: textClass = isUser ? 'text-white' : 'text-gray-100'
+  $: alignment = isUser ? 'flex-row-reverse' : 'flex-row'
+</script>
+
+<div class="flex {alignment} gap-4 px-4 py-4 hover:bg-gray-800/50 transition-colors">
+  <div class="flex-shrink-0 w-8 h-8 rounded-full flex items-center justify-center {bgClass}">
+    <span class="text-xs {textClass}">
+      {isUser ? '👤' : '🤖'}
+    </span>
+  </div>
+
+  <div class="flex-1 max-w-3xl">
+    <div class="flex {alignment} gap-2 mb-1">
+      <span class="text-xs text-gray-400">
+        {isUser ? 'You' : 'Assistant'}
+      </span>
+      <span class="text-xs text-gray-500">
+        {message.timestamp.toLocaleTimeString()}
+      </span>
+    </div>
+    <div class="text-gray-100 leading-relaxed">
+      {message.text}
+    </div>
+  </div>
+</div>

--- a/src/components/MessageList.svelte
+++ b/src/components/MessageList.svelte
@@ -1,0 +1,37 @@
+<script>
+  import Message from './Message.svelte'
+  import { afterUpdate } from 'svelte'
+
+  export let messages = []
+
+  let scrollContainer
+
+  afterUpdate(() => {
+    if (scrollContainer) {
+      scrollContainer.scrollTop = scrollContainer.scrollHeight
+    }
+  })
+</script>
+
+<div class="flex-1 overflow-y-auto scrollbar-thin scrollbar-thumb-gray-600 scrollbar-track-gray-800" bind:this={scrollContainer}>
+  <div class="max-w-4xl mx-auto">
+    {#each messages as message (message.id)}
+      <Message {message} />
+    {/each}
+  </div>
+</div>
+
+<style>
+  :global(.scrollbar-thin) {
+    scrollbar-width: thin;
+  }
+
+  :global(.scrollbar-thumb-gray-600::-webkit-scrollbar-thumb) {
+    background-color: rgb(75, 85, 99);
+    border-radius: 6px;
+  }
+
+  :global(.scrollbar-track-gray-800::-webkit-scrollbar-track) {
+    background-color: rgb(31, 41, 55);
+  }
+</style>

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,8 @@
+import App from './App.svelte'
+import './app.css'
+
+const app = new App({
+  target: document.getElementById('app'),
+})
+
+export default app

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -1,0 +1,5 @@
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte'
+
+export default {
+  preprocess: vitePreprocess(),
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: [
+    "./index.html",
+    "./src/**/*.{js,ts,jsx,tsx,svelte}",
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite'
+import { svelte } from '@sveltejs/vite-plugin-svelte'
+
+export default defineConfig({
+  plugins: [svelte()],
+  base: '/claude-agi/',
+})


### PR DESCRIPTION
ChatGPT風のchaseアプリを実装しました。

## 注目すべき部分

- Svelte + Vite + Tailwind CSSを使用
- ChatGPT風のchase UIィルイん
- ローカルストレージで会話履歴を保持
- GitHub Pagesでデプロイ可能

## 関連イシュー

Closes #91

Generated with [Claude Code](https://claude.ai/code)