### PR TITLE
feat: enhance responsive design for mobile and tablet devices

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -2,7 +2,7 @@
   import ChatContainer from './components/ChatContainer.svelte'
 </script>
 
-<div class="h-screen bg-gray-900">
+<div class="w-screen h-screen bg-gray-900 overflow-hidden">
   <ChatContainer />
 </div>
 

--- a/src/components/ChatContainer.svelte
+++ b/src/components/ChatContainer.svelte
@@ -65,8 +65,8 @@
 </script>
 
 <div class="flex flex-col h-full">
-  <div class="bg-gray-800 border-b border-gray-700 px-4 py-3">
-    <h1 class="text-white text-lg font-semibold">Chat Assistant</h1>
+  <div class="bg-gray-800 border-b border-gray-700 px-3 sm:px-4 py-2 sm:py-3">
+    <h1 class="text-white text-base sm:text-lg font-semibold">Chat Assistant</h1>
   </div>
 
   <MessageList {messages} />

--- a/src/components/ChatInput.svelte
+++ b/src/components/ChatInput.svelte
@@ -21,21 +21,22 @@
   }
 </script>
 
-<div class="border-t border-gray-700 bg-gray-800 px-4 py-4">
-  <div class="max-w-4xl mx-auto flex gap-3">
+<div class="border-t border-gray-700 bg-gray-800 px-2 sm:px-4 py-3 sm:py-4">
+  <div class="max-w-2xl sm:max-w-3xl lg:max-w-4xl mx-auto flex gap-2 sm:gap-3">
     <textarea
       bind:value={input}
       on:keydown={handleKeydown}
       placeholder="メッセージを入力..."
-      class="flex-1 bg-gray-700 text-white rounded-lg px-4 py-3 resize-none focus:outline-none focus:ring-2 focus:ring-blue-500 placeholder-gray-500"
+      class="flex-1 bg-gray-700 text-white rounded-lg px-3 sm:px-4 py-2 sm:py-3 text-sm sm:text-base resize-none focus:outline-none focus:ring-2 focus:ring-blue-500 placeholder-gray-500"
       rows="1"
     />
     <button
       on:click={handleSend}
       disabled={!input.trim() || isLoading}
-      class="bg-blue-600 hover:bg-blue-700 disabled:bg-gray-600 disabled:cursor-not-allowed text-white rounded-lg px-6 py-3 font-medium transition-colors flex items-center gap-2"
+      class="bg-blue-600 hover:bg-blue-700 disabled:bg-gray-600 disabled:cursor-not-allowed text-white rounded-lg px-3 sm:px-6 py-2 sm:py-3 font-medium transition-colors flex items-center gap-2 whitespace-nowrap flex-shrink-0"
     >
-      <span>送信</span>
+      <span class="hidden sm:inline">送信</span>
+      <span class="sm:hidden">送</span>
       {#if isLoading}
         <svg class="animate-spin h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
           <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>

--- a/src/components/Message.svelte
+++ b/src/components/Message.svelte
@@ -7,23 +7,23 @@
   $: alignment = isUser ? 'flex-row-reverse' : 'flex-row'
 </script>
 
-<div class="flex {alignment} gap-4 px-4 py-4 hover:bg-gray-800/50 transition-colors">
-  <div class="flex-shrink-0 w-8 h-8 rounded-full flex items-center justify-center {bgClass}">
+<div class="flex {alignment} gap-2 sm:gap-3 px-2 sm:px-4 py-3 sm:py-4 hover:bg-gray-800/50 transition-colors">
+  <div class="flex-shrink-0 w-7 h-7 sm:w-8 sm:h-8 rounded-full flex items-center justify-center {bgClass}">
     <span class="text-xs {textClass}">
       {isUser ? '👤' : '🤖'}
     </span>
   </div>
 
-  <div class="flex-1 max-w-3xl">
-    <div class="flex {alignment} gap-2 mb-1">
-      <span class="text-xs text-gray-400">
+  <div class="flex-1 max-w-xs sm:max-w-md md:max-w-2xl lg:max-w-3xl">
+    <div class="flex {alignment} gap-1 sm:gap-2 mb-1">
+      <span class="text-xs text-gray-400 whitespace-nowrap">
         {isUser ? 'You' : 'Assistant'}
       </span>
-      <span class="text-xs text-gray-500">
+      <span class="text-xs text-gray-500 whitespace-nowrap">
         {message.timestamp.toLocaleTimeString()}
       </span>
     </div>
-    <div class="text-gray-100 leading-relaxed">
+    <div class="text-sm sm:text-base text-gray-100 leading-relaxed break-words">
       {message.text}
     </div>
   </div>

--- a/src/components/MessageList.svelte
+++ b/src/components/MessageList.svelte
@@ -14,7 +14,7 @@
 </script>
 
 <div class="flex-1 overflow-y-auto scrollbar-thin scrollbar-thumb-gray-600 scrollbar-track-gray-800" bind:this={scrollContainer}>
-  <div class="max-w-4xl mx-auto">
+  <div class="max-w-2xl sm:max-w-3xl lg:max-w-4xl mx-auto px-2 sm:px-4">
     {#each messages as message (message.id)}
       <Message {message} />
     {/each}


### PR DESCRIPTION
ChatGPT風チャットアプリのレスポンシブデザインをエンハンスしました。

## 変更内容

- Tailwind CSS レスポンシブクラス (sm:, md:, lg:) を全コンポーネントに追加
- モバイルでは小さなパディング,デスクトップでは大きなパディング
- フォントサイズも伊調整
- レスポンシブルコンテナ最大幅を設定
- モバイルでのボタンテキストを最適化
- テキスト折り返しを改善

Closes #91

Generated with [Claude Code](https://claude.ai/code)